### PR TITLE
Changes to allow for tournaments, head-to-head matchups, etc.

### DIFF
--- a/race_simulation.py
+++ b/race_simulation.py
@@ -4,35 +4,114 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
-def trackSim(name, distance, time, nplayers=10, interval=1):
+
+def create_players():
+    """ Creates a dictionary containing racer info based on user input
+    that can be passed to trackSim().
+
+    Returns
+    -------
+    A dictionary containing the inputted racer info.
+    """
+
+    number_of_players = int(input('How many players? '))
+    names = []
+    velocity = []
+    for i in np.arange(number_of_players):
+        names.append(input('Name of player {}? '.format(i+1)))
+        velocity.append(float(input('Speed of player {} (mph)? '.\
+        	            format(i+1))) / 2.237)  # convert mph to meters/s
+    d = dict({})
+    d['name'] = names
+    d['velocity'] = velocity
+    return d
+
+def simulate(distance):
+    """Simulates a race without plotting.
+
+    Parameters
+    ----------
+    distance : int
+        The length you want your player to run for (meters).
+
+    Returns
+    -------
+    rankings : list
+        The results of the race.
+    """
+    
+    # Create racers from user input
+    player_info = create_players()
+    nplayers = len(player_info['name'])
+    
+    class Ball(object):
+        def __init__(self, input_name, x, y, v):
+            """
+            :param x y: Initial position.
+            :param v: Initial velocity.
+            """
+
+            self.v = float(v)
+            self.x = float(x)
+            self.y = float(y)
+            self.name = input_name
+
+        def update(self):
+            self.x += self.v
+            if self.x >= distance:
+                if self.name not in rankings:
+                    final_time = np.round((1/self.v)*distance, 2)
+                    print(self.name, ' with a final time of '
+                                     + str(final_time)
+                                     + ' seconds')
+                    rankings.append(self.name)
+
+    # create the balls
+    balls = []
+    for n in np.arange(0, nplayers):
+        runner_pos = n+1
+        ball = Ball(player_info['name'][n], 0, runner_pos,
+                    player_info['velocity'][n])
+        balls.append(ball)
+    
+    # run the race
+    rankings = []
+    while len(rankings) != nplayers:
+        for ball in balls:
+            ball.update()
+            if len(rankings) == nplayers:
+                print(rankings)
+                return rankings
+
+def trackSim(distance, interval=1):
     """ Runs the track simulator!
 
     Parameters
     ----------
-    name : str
-        Your name (or whichever name you want your player to have).
     distance : int
         The length you want your player to run for (meters).
-    time : int
-        Your average time for the selected distance (seconds).
-    nplayers : int
-        The amount of runners you want to compete against.
     interval : int (default = 1)
         The time (in milliseconds) in between frames. Essentially, this
         parameter adjusts how long you want the race simulation to run.
         The lower this number, the shorter the duration. To run the simulation
         in real-time, the input value should be 1000.
+    plot : boob (default = True)
+        Set to True to watch the race
 
     Returns
     -------
     A matplotlib animation with the race simulation.
     """
-    #~~~~~~Bounds of the racetrack~~~~~~
-    xlim = (0,distance+(0.5*distance))
-    ylim = (0,nplayers+1)
-    player_pos = nplayers/2 # starting position of the player
 
-    #~~~~~~Figure Aesthetics~~~~~~
+    # Create racers from user input
+    player_info = create_players()
+
+   	# ~~~~~~Bounds of the racetrack~~~~~~
+    xlim = (0, distance+(0.5*distance))
+    nplayers = len(player_info['name'])
+    ylim = (0, nplayers+1.0)
+
+    # ~~~~~~Figure Aesthetics~~~~~~
     fig = plt.figure()
     ax = fig.add_subplot(111, autoscale_on=False, xlim=xlim, ylim=ylim)
     plt.axvline(distance, color='k')
@@ -40,33 +119,28 @@ def trackSim(name, distance, time, nplayers=10, interval=1):
     plt.style.use('seaborn-pastel')
 
     class Ball(object):
-
         def __init__(self, input_name, x, y, v):
             """
             :param x y: Initial position.
             :param v: Initial velocity.
             """
+
             self.v = float(v)
             self.x = float(x)
             self.y = float(y)
             self.name = input_name
-
             self.scatter, = ax.plot([], [], 'o', markersize=20)
-
-            #self.text, = ax.annotate(str(self.name), xy=([], []))
 
         def update(self):
             self.x += self.v
             self.scatter.set_data(self.x, self.y)
-            #self.text.set_text(self.x, self.y)
-
             if self.x >= distance:
                 self.scatter.set_data(distance, self.y)
                 if self.name not in rankings:
                     final_time = np.round((1/self.v)*distance, 2)
-                    print(self.name, ' with a final time of '\
-                                     +str(final_time)\
-                                     +' seconds')
+                    print(self.name, ' with a final time of '
+                                     + str(final_time)
+                                     + ' seconds')
                     rankings.append(self.name)
 
         def start(self):
@@ -76,43 +150,37 @@ def trackSim(name, distance, time, nplayers=10, interval=1):
         return []
 
     def animate(t):
-
-        if t==0.0:
+        if t == 0.0:
             print('starting!!')
             for ball in balls:
                 ball.start()
         else:
             for ball in balls:
                 ball.update()
-
-                if len(rankings)==len(balls):
+                if len(rankings) == len(balls):
                     ani.event_source.stop()
-                    #print(rankings)
 
         # have to return an iterable
         return [ball.scatter for ball in balls]
 
     frames = np.arange(0, distance, .001)
 
-    limit = 0.2*time
-
+    # create the balls
     balls = []
-    for n in np.arange(0, nplayers+1, 1):
-        runner_pos = 0+n
+    for n in np.arange(0, nplayers):
+        runner_pos = n+1
+        ball = Ball(player_info['name'][n], 0, runner_pos,
+                    player_info['velocity'][n])
+        balls.append(ball)
 
-        if runner_pos != player_pos:
-            runner_time = random.randint(time-limit,time+limit)
-            ball = Ball('runner '+str(n), 0, runner_pos, distance/runner_time)
-            balls.append(ball)
-
-    player_name = Ball(name, 0, player_pos, distance/time)
-
-    balls.append(player_name)
-
+    # run the simulation
     rankings = []
     ani = animation.FuncAnimation(fig, animate, frames, init_func=init,
                                   interval=interval, blit=True, repeat=False)
     plt.show()
+    print(rankings)
+
+    return
 
 def parse_args():
     """ Parses command line arguments.
@@ -124,49 +192,27 @@ def parse_args():
     """
 
     # Create help strings
-    name_help = 'Your name (or whichever name you want your player to have).'
     distance_help = 'The length you want your player to run for (meters).'
-    time_help = 'Your average time for the selected distance (seconds).'
-    nplayers_help = 'The amount of runners you want to compete against. Default = 10 runners.'
-    interval_help = 'The time (in milliseconds) in between frames. Default = 1 millisecond.'
-
+    interval_help = ('The time (in milliseconds) in between frames. '
+    	             'Default = 1 millisecond.')
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-n',
-        dest='name',
-        action='store',
-        type=str,
-        required=True,
-        help=name_help)
     parser.add_argument('-d',
-        dest='distance',
-        action='store',
-        type=int,
-        required=True,
-        help=distance_help)
-    parser.add_argument('-t',
-        dest='time',
-        type=int,
-        action='store',
-        required=True,
-        help=time_help)
-    parser.add_argument('-p',
-        dest='nplayers',
-        action='store',
-        type=int,
-        required=False,
-        default=10,
-        help=nplayers_help)
+                        dest='distance',
+                        action='store',
+                        type=int,
+                        required=True,
+                        help=distance_help)
     parser.add_argument('-i --interval',
-        dest='interval',
-        action='store',
-        type=int,
-        required=False,
-        help=interval_help,
-        default=1)
+                        dest='interval',
+                        action='store',
+                        type=int,
+                        required=False,
+                        help=interval_help,
+                        default=1)
 
     # Set defaults
-    parser.set_defaults(nplayers=10, interval=1)
+    parser.set_defaults(distance=800, interval=1)
 
     # Parse args
     args = parser.parse_args()
@@ -178,4 +224,4 @@ if __name__ == '__main__':
 
     args = parse_args()
 
-    trackSim(args.name, args.distance, args.time, args.nplayers, args.interval)
+    trackSim(args.distance, args.interval)


### PR DESCRIPTION
Allows a dictionary of ball characteristics to be used as input to the track simulator (only user defined for now); created option to run the race simulator without plotting. Both of these are needed to allow for large tournament simulations, head-to-heads, etc.

These changes also lay the groundwork for pandas dataframes to be used as input to the race simulations (which could be used to store tournament results, seasons, etc.). And non-user rounds could be simulated with or without watching the races.

For now, I simplified the command line arguments for ease of testing, but they should probably be put back in eventually to allow for automatic player generation without user input questions.

An example of how to run without plotting:
![image](https://user-images.githubusercontent.com/16088329/60747620-690c6500-9f54-11e9-9af3-b38a6e953a92.png)

An example of how to run with plotting:
`python race_simulation.py -d 800`